### PR TITLE
feat: Add scheduled tasks for logging at fixed intervals

### DIFF
--- a/credit-card/src/main/kotlin/com/credit/card/app/configuration/CreditCardConfiguration.kt
+++ b/credit-card/src/main/kotlin/com/credit/card/app/configuration/CreditCardConfiguration.kt
@@ -1,6 +1,8 @@
 package com.credit.card.app.configuration
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
+@EnableScheduling
 class CreditCardConfiguration

--- a/credit-card/src/main/kotlin/com/credit/card/app/configuration/ScheduledTasks.kt
+++ b/credit-card/src/main/kotlin/com/credit/card/app/configuration/ScheduledTasks.kt
@@ -1,0 +1,21 @@
+package com.credit.card.app.configuration
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class ScheduledTasks {
+
+    private val logger = LoggerFactory.getLogger(ScheduledTasks::class.java)
+
+    @Scheduled(fixedRate = 10000)
+    fun logEveryTenSeconds() {
+        logger.info("this should not be logging")
+    }
+
+    @Scheduled(fixedRate = 300000)
+    fun logEveryFiveMinutes() {
+        logger.info("this is a good log")
+    }
+}


### PR DESCRIPTION
Introduced a `ScheduledTasks` component with two scheduled methods: one logs every 10 seconds, and another logs every 5 minutes. Enabled scheduling in the `CreditCardConfiguration` class to support this functionality.